### PR TITLE
Fixação da versão do werkzeug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
 gunicorn
+werkzeug==2.0.3


### PR DESCRIPTION
Fixação da versão do werkzeug devido a remoção do argumento "as_tuple" usado nos testes pelo flask, ocasionando falha no deploy pela pipeline.